### PR TITLE
Fix extrapolated battery not updating while driving

### DIFF
--- a/custom_components/uconnect/extrapolated_soc.py
+++ b/custom_components/uconnect/extrapolated_soc.py
@@ -372,11 +372,11 @@ class UconnectExtrapolatedSocSensor(RestoreEntity, SensorEntity, UconnectEntity)
 
             # Only update SOC when charging/driving and new value exceeds extrapolated
             # When idle (parked), car data is stale and shouldn't reset extrapolation
-            # Use self._state.is_idle (previous state) to allow fresh data when
-            # transitioning from driving to idle
+            # Only skip if car WAS idle AND IS STILL idle - any state transition
+            # (idle→driving or driving→idle) means fresh data
             current_extrapolated = self.native_value
             is_idle = not is_charging and not ignition_on
-            if soc_changed and self._state.is_idle:
+            if soc_changed and self._state.is_idle and is_idle:
                 _LOGGER.debug(
                     "Skipping SOC update for %s: car is idle, data is stale",
                     self.vehicle.vin,


### PR DESCRIPTION
Sorry, this car is not driven that much at the moment, so it takes some time to see the issues.

When transitioning from driving to parked, the fresh SOC was incorrectly
skipped because the code checked the current idle state instead of the
previous state. Now checks self._state.is_idle to allow fresh data when
transitioning from driving to idle.

The previous fix only handled driving→idle transition. This also handles
idle→driving by requiring both previous AND current state to be idle
before skipping the SOC update.

Now the logic should correctly handles all transitions:                                                                    
  - Parked → parked: skip (stale cached data)                                                                         
  - Parked → driving: accept (ignition on means fresh data)                                                           
  - Driving → parked: accept (just finished driving, fresh data)                                                      
  - Driving → driving: accept (fresh data)                  