### PR TITLE
Some logic fixes and a new button to reset battery learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ US, Canada, EU & Asia regions are supported. Try a different region if the origi
 
 - Imports statistics like battery level 🔋, tire pressure ‍💨, odometer ⏲ etc. into Home Assistant
 - **Extrapolated Battery**: For EVs, provides a real-time battery estimate between API updates by tracking charging rate and idle drain. Automatically rejects stale data that would show impossible values (e.g., battery dropping while charging), and correctly handles state transitions (e.g., idle to charging, charging to driving)
+- **Reset Battery Learning**: Button to reset the learned charging correction factor and idle drain rate back to defaults. Useful when changing chargers or if learned values have drifted
 - Multiple Brands: Abarth, Alfa Romeo, Chrysler, Dodge, Fiat, Jeep, Maserati & Ram
 - Multiple Regions: America, Canada, Europe & Asia
 - Supports multiple cars on the same account 🚙🚗🚕

--- a/custom_components/uconnect/coordinator.py
+++ b/custom_components/uconnect/coordinator.py
@@ -38,6 +38,7 @@ class UconnectDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Initialize the coordinator."""
         self.platforms: set[str] = set()
+        self.extrapolated_soc_sensors: dict = {}
 
         # Try to get PIN from the options object,
         # if it's empty there - then from the data object

--- a/custom_components/uconnect/extrapolated_soc.py
+++ b/custom_components/uconnect/extrapolated_soc.py
@@ -313,6 +313,13 @@ class UconnectExtrapolatedSocSensor(RestoreEntity, SensorEntity, UconnectEntity)
         await super().async_will_remove_from_hass()
 
     @callback
+    def reset_learning(self) -> None:
+        """Reset learned correction factor and drain rate to defaults."""
+        self._state.learned_correction_factor = DEFAULT_CORRECTION_FACTOR
+        self._state.idle_drain_rate_pct_per_hour = DEFAULT_IDLE_DRAIN_RATE
+        self.async_write_ha_state()
+
+    @callback
     def _async_update_extrapolation(self, _now: datetime) -> None:
         """Periodically update the extrapolated value."""
         # Update if charging or idle (both need extrapolation)

--- a/custom_components/uconnect/sensor.py
+++ b/custom_components/uconnect/sensor.py
@@ -215,7 +215,9 @@ async def async_setup_entry(
 
         # Add extrapolated SOC sensors for EVs/PHEVs
         if getattr(vehicle, "state_of_charge", None) is not None:
-            entities.append(UconnectExtrapolatedSocSensor(coordinator, vehicle))
+            sensor = UconnectExtrapolatedSocSensor(coordinator, vehicle)
+            entities.append(sensor)
+            coordinator.extrapolated_soc_sensors[vehicle.vin] = sensor
             entities.append(UconnectChargingRateSensor(coordinator, vehicle))
 
     async_add_entities(entities)


### PR DESCRIPTION
It all concerns extrapolated SOC.

I found some logic issues and I added more persistence.
I also added a button to reset battery learning. That would solve issues if the learning info is completely off, like mine since it learnt bad data when I was developing the SOC extrapolation.