### PR TITLE
Fix charging rate sensor oscillation and preserve rate across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ US, Canada, EU & Asia regions are supported. Try a different region if the origi
 
 - Imports statistics like battery level 🔋, tire pressure ‍💨, odometer ⏲ etc. into Home Assistant
 - **Extrapolated Battery**: For EVs, provides a real-time battery estimate between API updates by tracking charging rate and idle drain. Automatically rejects stale data that would show impossible values (e.g., battery dropping while charging), and correctly handles state transitions (e.g., idle to charging, charging to driving). Triggers an automatic deep refresh when charging starts after idle to get fresh SOC data. Preserves the charging rate across sessions so that extrapolation begins immediately when a new charging session starts, even before time-to-full data is available from the API
-- **Charging Rate**: Shows the current charging speed in %/hour. Computed from observed SOC changes between API updates for accuracy, with a time-to-full estimate as fallback for the first reading of a session
+- **Charging Rate**: Shows the current charging speed in %/hour. Computed over a 60-minute sliding window of SOC readings for stable output even with integer SOC values and irregular polling. Falls back to a time-to-full estimate during the first hour of a session
 - **Reset Battery Learning**: Button to reset the learned charging correction factor and idle drain rate back to defaults. Useful when changing chargers or if learned values have drifted
 - Multiple Brands: Abarth, Alfa Romeo, Chrysler, Dodge, Fiat, Jeep, Maserati & Ram
 - Multiple Regions: America, Canada, Europe & Asia

--- a/custom_components/uconnect/extrapolated_soc.py
+++ b/custom_components/uconnect/extrapolated_soc.py
@@ -7,6 +7,7 @@ from the vehicle, based on charging status and time-to-full estimates.
 from __future__ import annotations
 
 import logging
+from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
@@ -43,6 +44,7 @@ MAX_CORRECTION_FACTOR = 1.5  # Maximum allowed correction factor
 CORRECTION_EMA_ALPHA = 0.3  # Exponential moving average factor for correction learning
 MIN_TIME_FOR_LEARNING_HOURS = 0.05  # Minimum 3 minutes for learning
 MIN_SOC_CHANGE_FOR_LEARNING = 0.5  # Minimum 0.5% SOC change for learning
+CHARGING_RATE_WINDOW = timedelta(minutes=60)  # Sliding window for rate computation
 
 # Constants for idle drain estimation
 DEFAULT_IDLE_DRAIN_RATE = 0.006  # Default 0.006%/hour ≈ 1%/week ≈ 4%/month
@@ -779,8 +781,7 @@ class UconnectChargingRateSensor(SensorEntity, UconnectEntity):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_icon = "mdi:battery-charging-high"
 
-        self._prev_soc: float | None = None
-        self._prev_soc_time: datetime | None = None
+        self._soc_history: deque[tuple[datetime, float]] = deque()
         self._observed_rate: float | None = None
 
     @callback
@@ -790,27 +791,26 @@ class UconnectChargingRateSensor(SensorEntity, UconnectEntity):
         current_soc = getattr(self.vehicle, "state_of_charge", None)
 
         if not is_charging or current_soc is None:
-            self._prev_soc = None
-            self._prev_soc_time = None
+            self._soc_history.clear()
             self._observed_rate = None
             self.async_write_ha_state()
             return
 
         now = datetime.now(timezone.utc)
+        self._soc_history.append((now, current_soc))
 
-        if self._prev_soc is not None and self._prev_soc_time is not None:
-            delta = current_soc - self._prev_soc
-            if delta >= MIN_SOC_CHANGE_FOR_LEARNING:
-                elapsed_hours = (now - self._prev_soc_time).total_seconds() / 3600.0
-                if elapsed_hours >= MIN_TIME_FOR_LEARNING_HOURS:
-                    self._observed_rate = min(delta / elapsed_hours, 300.0)
-                self._prev_soc = current_soc
-                self._prev_soc_time = now
-            # If delta too small, same, or dropped: keep prev values
-        else:
-            # First reading while charging
-            self._prev_soc = current_soc
-            self._prev_soc_time = now
+        # Trim entries outside the sliding window
+        cutoff = now - CHARGING_RATE_WINDOW
+        while self._soc_history and self._soc_history[0][0] < cutoff:
+            self._soc_history.popleft()
+
+        # Compute rate across the window span
+        if len(self._soc_history) >= 2:
+            oldest_time, oldest_soc = self._soc_history[0]
+            elapsed_hours = (now - oldest_time).total_seconds() / 3600.0
+            delta = current_soc - oldest_soc
+            if elapsed_hours >= MIN_TIME_FOR_LEARNING_HOURS and delta >= 0:
+                self._observed_rate = min(delta / elapsed_hours, 300.0)
 
         self.async_write_ha_state()
 


### PR DESCRIPTION
Fix charging rate sensor oscillation with sliding window approach.

Replace point-to-point rate calculation with a 60-minute sliding window that computes rate across all SOC readings in the window. This eliminates erratic spikes caused by integer SOC quantization and irregular polling intervals (e.g. manual deep refreshes).

The time-to-full estimate still serves as fallback during the first hour of a charging session before the window has enough data.

Also preserves charging rate across sessions: stop zeroing charging_rate_pct_per_hour when charging ends, so the previous session's rate serves as a fallback. Add a _has_session_rate flag to track whether the rate was derived from current session data (observed or time-to-full).

Priority chain: observed rate > current time-to-full > stale rate > 0.

Fixes #87