### PR TITLE
feat: Add suggested_display_precision to sensors and respect display_precision in vehicle card

### DIFF
--- a/custom_components/uconnect/frontend/uconnect-vehicle-card.js
+++ b/custom_components/uconnect/frontend/uconnect-vehicle-card.js
@@ -25,11 +25,20 @@ const normalizeState = (stateObj) => {
   return String(raw).trim().toLowerCase();
 };
 
-const formatState = (stateObj) => {
+const formatState = (stateObj, hass) => {
   if (!stateObj) return "\u2014";
   const state = stateObj.state;
   if (state === "unknown" || state === "unavailable") return "\u2014";
   const unit = stateObj.attributes?.unit_of_measurement;
+  const num = Number(state);
+  if (Number.isFinite(num)) {
+    const entityId = stateObj.entity_id;
+    const precision = hass?.entities?.[entityId]?.display_precision;
+    if (precision !== undefined && precision !== null) {
+      const formatted = num.toFixed(precision);
+      return unit ? `${formatted} ${unit}` : `${formatted}`;
+    }
+  }
   return unit ? `${state} ${unit}` : `${state}`;
 };
 
@@ -644,13 +653,13 @@ class UconnectVehicleCard extends HTMLElement {
     const fuelValue = clamp(toNumberOrZero(read("fuel")), 0, 100);
 
     const primaryLevelValue = hasSoc ? socValue : hasFuel ? fuelValue : 0;
-    const primaryLevelLabel = hasSoc ? `${socValue}%` : hasFuel ? `${fuelValue}%` : "\u2014";
+    const primaryLevelLabel = hasSoc ? `${Math.round(socValue)}%` : hasFuel ? `${Math.round(fuelValue)}%` : "\u2014";
     const primaryLevelEntity = hasSoc ? (entities.soc || "") : hasFuel ? (entities.fuel || "") : "";
     const primaryLevelHasBar = hasSoc || hasFuel;
 
     const rangeState = hasRange ? read("range") : hasRangeTotal ? read("range_total") : null;
     const rangeEntity = hasRange ? (entities.range || "") : hasRangeTotal ? (entities.range_total || "") : "";
-    const rangeText = rangeState ? formatState(rangeState) : "\u2014";
+    const rangeText = rangeState ? formatState(rangeState, hass) : "\u2014";
     const rangeIcon = hasSoc ? "mdi:arrow-left-right" : "mdi:gas-station";
 
     // Indicators
@@ -832,13 +841,13 @@ class UconnectVehicleCard extends HTMLElement {
         {
           icon: "mdi:car-battery",
           label: "12V Battery",
-          value: formatState(read("battery_voltage")),
+          value: formatState(read("battery_voltage"), hass),
           entity: entities.battery_voltage || "",
         },
         {
           icon: "mdi:counter",
           label: "Odometer",
-          value: formatState(read("odometer")),
+          value: formatState(read("odometer"), hass),
           entity: entities.odometer || "",
         },
       ].filter((item) => item && firstDefined(item.entity, item.value) !== "");

--- a/custom_components/uconnect/sensor.py
+++ b/custom_components/uconnect/sensor.py
@@ -48,6 +48,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UNIT_DYNAMIC,
+        suggested_display_precision=2,
     ),
     UconnectSensorEntityDescription(
         key="distance_to_empty",
@@ -56,6 +57,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=UNIT_DYNAMIC,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="range_gas",
@@ -64,6 +66,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=UNIT_DYNAMIC,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="range_total",
@@ -72,6 +75,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=UNIT_DYNAMIC,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="state_of_charge",
@@ -79,6 +83,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.BATTERY,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="charging_level",
@@ -92,6 +97,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.VOLTAGE,
+        suggested_display_precision=1,
     ),
     UconnectSensorEntityDescription(
         key="time_to_fully_charge_l2",
@@ -100,6 +106,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfTime.MINUTES,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.DURATION,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="time_to_fully_charge_l3",
@@ -108,6 +115,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfTime.MINUTES,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.DURATION,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="distance_to_service",
@@ -116,6 +124,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=UNIT_DYNAMIC,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="days_to_service",
@@ -124,6 +133,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=UnitOfTime.DAYS,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="wheel_front_left_pressure",
@@ -132,6 +142,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UNIT_DYNAMIC,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="wheel_front_right_pressure",
@@ -140,6 +151,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UNIT_DYNAMIC,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="wheel_rear_left_pressure",
@@ -148,6 +160,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UNIT_DYNAMIC,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="wheel_rear_right_pressure",
@@ -156,6 +169,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UNIT_DYNAMIC,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="oil_level",
@@ -163,6 +177,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         icon="mdi:oil",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="fuel_amount",
@@ -170,6 +185,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         icon="mdi:fuel",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="timestamp_info",
@@ -199,6 +215,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         key="battery_state_of_charge",
         name="Battery State of Charge",
         icon="mdi:battery",
+        suggested_display_precision=0,
     ),
     UconnectSensorEntityDescription(
         key="time_to_fully_charge_l1",
@@ -207,6 +224,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[UconnectSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfTime.MINUTES,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.DURATION,
+        suggested_display_precision=0,
     ),
 )
 


### PR DESCRIPTION
### Problem

Numeric sensor values are displayed with excessive decimal places throughout the integration -- both in standard HA cards and the bundled vehicle card.

Examples:
- Odometer: `25209.6506402609 mi` instead of `25209.65 mi`
- Driving Range: `81.3996261830908 mi` instead of `81 mi`
- Tire Pressure: `71.0025023361954 psi` instead of `71 psi`

### Changes

**`sensor.py`** -- Add `suggested_display_precision` to all 18 numeric sensor descriptions:

| Sensor type | Precision | Example |
|-------------|-----------|---------|
| Odometer | 2 | `25209.65 mi` |
| Driving range (all variants) | 0 | `81 mi` |
| Distance to service | 0 | `3200 mi` |
| Days to service | 0 | `45 days` |
| Battery voltage | 1 | `13.8 V` |
| Tire pressure (4 sensors) | 0 | `71 psi` |
| Oil life | 0 | `36%` |
| Fuel remaining | 0 | `9%` |
| State of charge (HV + standard) | 0 | `85%` |
| Time to charge (L1/L2/L3) | 0 | `120 min` |

This is a built-in HA mechanism -- `suggested_display_precision` on `SensorEntityDescription` tells the frontend how to format values by default. Users can still override per-entity in the UI.

Non-numeric sensors (timestamps, fuel type, charger type) are unaffected.

**`uconnect-vehicle-card.js`** -- `formatState()` now reads `hass.entities[entityId].display_precision` and formats numeric values with `toFixed()`:
- Fully backward compatible -- falls through to raw state when no precision is configured
- SOC/fuel percentage bar label uses `Math.round()` for clean display
- All `formatState()` call sites pass the `hass` object

### Before / After

| Sensor | Before | After |
|--------|--------|-------|
| Odometer | 25209.6506402609 mi | 25209.65 mi |
| Fuel Range | 81.3996261830908 mi | 81 mi |
| Tires | 71.0025023361954 psi | 71 psi |
| 12V Battery | 13.8 V | 13.8 V |

### Testing

- Tested on a 2023 Ram 2500 (diesel, US region)
- Verified standard HA tile cards and the bundled uconnect-vehicle-card both display rounded values
- No change to raw `native_value` -- only display formatting is affected
- Backward compatible: cards without precision configured behave identically to before